### PR TITLE
link to latest downloaded file

### DIFF
--- a/lib/request_handler.js
+++ b/lib/request_handler.js
@@ -10,36 +10,64 @@
 'use strict';
 
 var Promise = require('bluebird');
-const fs = require("fs");
-const request = require('superagent');
+var fs =  require('fs');
+// var fs = Promise.promisifyAll(require("fs"));
+var request = require('superagent');
 var progress = require('superagent-progress');
 
-module.exports = {
-    saveFile: (responseBody, destination) => {
-        return new Promise((response) => {
-            let url = responseBody.hdurl;
-            if(url){
-                console.log('Downloading picture....');
-                let stream = request
-                    .get(url)
-                    .use(progress)
-                    .pipe(fs.createWriteStream(destination + '/current.jpg'));
-                responseBody.localFile = stream.path;
-                return response(responseBody);
-            }
+var getFileFromPath = (path) => {
+  return path.substring(path.lastIndexOf('/') +1);
+};
 
-            return response(null);
+module.exports = {
+  saveFile: (responseBody) => {
+    return new Promise((resolve, reject) => {
+      let url = responseBody.hdurl;
+      if (url) {
+        let destination = responseBody.destination + '/' + getFileFromPath(url);
+        console.log('Downloading picture....');
+        let stream = request
+          .get(url)
+          .use(progress)
+          .pipe(fs.createWriteStream(destination));
+
+        stream.on('finish', () => {
+         responseBody.localFile = stream.path;
+          resolve(responseBody);
         });
-    },
-    updateEXIF: (responseBody) => {
-        return new Promise((response) => {
-            if(responseBody && responseBody.localFile) {
-                console.log('updating EXIF for file: %s', responseBody.localFile);
-                return response(responseBody);
+
+        stream.on('error', (err) => {
+          reject(err);
+        })
+      }
+    });
+  },
+  updateEXIF: (responseBody) => {
+    return new Promise((resolve) => {
+      if (responseBody && responseBody.localFile) {
+        let localFile = responseBody.localFile;
+        console.log('updating EXIF for file: %s', localFile);
+        resolve(responseBody);
+      }
+    });
+  },
+  linkFile: (responseBody) => {
+    return new Promise((resolve, reject) => {
+      if(responseBody && responseBody.localFile) {
+        let localFile = responseBody.localFile;
+        console.log('linking %s to latest.jpg', localFile);
+        let linkedFile = responseBody.destination + '/' + 'latest.jpg';
+
+        fs.symlink(localFile, linkedFile,(err) => {
+          if(err){
+            if(err.code !== 'EEXIST') {
+              reject(err);
             }
-            
-            return response(null);
+          }
+          resolve(responseBody);
         });
-    }
+      }
+    });
+  }
 };
 

--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const fs = require("fs");
+const fs = require('fs');
 const path = require('path');
 const nconf = require('nconf');
 const request = require('superagent');
@@ -47,7 +47,12 @@ request
 
       return;
     }
+    res.body.destination = destination;
     requestHandler
-      .saveFile(res.body, destination)
-      .then(requestHandler.updateEXIF);
+      .saveFile(res.body)
+      .then(requestHandler.updateEXIF)
+      .then(requestHandler.linkFile)
+      .catch((err) => {
+        console.log(err);
+      });
   });


### PR DESCRIPTION
This update allows you to set you background to latest.jpg. Anytime you download a new file it will be symlinked so  that you don't need to update your background image.
- adding file linking to latest.jpg.
- the tool will download the file and not override it.
- later I will add a step to cleanup old files if needed.
